### PR TITLE
Add docker-launcher script to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ ARG ANSIBLE_VERSION=2.9.10
 ARG MOLECULE_VERSION=3.0.7
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
-COPY docker-launcher /docker-launcher
-RUN mv docker-launcher /usr/bin && \
-    chmod 500 /usr/bin/docker-launcher
+COPY docker-launcher /usr/bin/docker-launcher
+RUN chmod 500 /usr/bin/docker-launcher
 
 RUN yum install -y epel-release \
                 openssh-clients \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ARG ANSIBLE_VERSION=2.9.10
 ARG MOLECULE_VERSION=3.0.7
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
+COPY docker-launcher /docker-launcher
+RUN mv docker-launcher /usr/bin && \
+    chmod 500 /usr/bin/docker-launcher
+
 RUN yum install -y epel-release \
                 openssh-clients \
                 git \

--- a/docker-launcher
+++ b/docker-launcher
@@ -1,0 +1,109 @@
+#!/bin/bash
+# based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-120}
+
+sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  try_start() {
+    dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  export server_args LOG_FILE
+  declare -fx try_start
+  trap stop_docker EXIT
+
+  if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+    echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+    return 1
+  fi
+}
+
+stop_docker() {
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+}


### PR DESCRIPTION
There was a problem using the container in Concourse in terms of running docker in docker.
Initially we were starting dockerd in the task in Concourse but it was still causing issues.

This commit adds a docker-launcher script to the image which allows us to call a start_docker function.
The script will later be edited to a higher standard and make use of platform-tools-common with regards to logging etc. We wil also look to add the docker aspect to a platform-tools-docker as the script will likely be used again in other projects. A story will be brought into the next sprint to address this.

Resolves: DVOP-1454