### PR TITLE
Updating mirrors for centos8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ARG ANSIBLE_VERSION=2.9.10
 ARG MOLECULE_VERSION=3.0.7
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y epel-release \
                 openssh-clients \
                 iptables \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ ARG ANSIBLE_VERSION=2.9.10
 ARG MOLECULE_VERSION=3.0.7
 ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 
-RUN cd /etc/yum.repos.d/
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 RUN yum install -y epel-release \
                 openssh-clients \


### PR DESCRIPTION
Updating the mirror as CentOS 8 will no longer receive development resources from the official CentOS project and as of Dec 31st, 2021. The mirror with be archived permanently to [vault.centos.org](url)