### PR TITLE
Pin Ansible package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf install -y openssh-clients \
                 git \
                 docker
 
-RUN pip3 install ansible \
+RUN pip3 install ansible=='8.7.0' \
                  ansible-lint \
                  boto \
                  boto3 \


### PR DESCRIPTION
Currently the container image includes `ansible-core` version `2.15.7` which differs from both the version number indicated in the branch name (`2.15.6`) and the container image name in ECR. This change ensure we retain the correct version to avoid ambiguity.