### PR TITLE
Add findutils package to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG YUM_REPOSITORY=yum-repository.platform.aws.chdev.org
 RUN dnf install -y openssh-clients \
     python3-pip \
     git \
-    docker
+    docker \
+    findutils
 
 RUN pip3 install ansible-core=='2.15.6' \
     ansible \


### PR DESCRIPTION
Several [ci-concourse-resources](https://github.com/companieshouse/ci-concourse-resources) tasks that have been upgraded to use this container image make use of the `find` command which was present in the previous version of the container image. This change ensures that such tasks continue to function correctly with the new container image.